### PR TITLE
Fixed RemovedInDjango19Warning in models.py

### DIFF
--- a/favorites/models.py
+++ b/favorites/models.py
@@ -3,7 +3,7 @@
 from django.db import models
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.contenttypes import generic
+from django.contrib.contenttypes.fields import GenericForeignKey
 from django.utils.translation import ugettext_lazy as _
 
 if hasattr(settings, 'AUTH_USER_MODEL'):
@@ -52,7 +52,7 @@ class Favorite(models.Model):
     user = models.ForeignKey(User)
     content_type = models.ForeignKey(ContentType)
     object_id = models.PositiveIntegerField()
-    content_object = generic.GenericForeignKey('content_type', 'object_id')
+    content_object = GenericForeignKey('content_type', 'object_id')
     created_time = models.DateTimeField(auto_now_add=True)
 
     objects = FavoriteManager()


### PR DESCRIPTION
Was receiving the following warning when starting Django server:

models.py:6: RemovedInDjango19Warning:
django.contrib.contenttypes.generic is deprecated and will be removed in
Django 1.9. Its contents have been moved to the fields, forms, and admin
submodules of django.contrib.contenttypes.
  from django.contrib.contenttypes import generic
